### PR TITLE
Engade soporte para construir o PDF en Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,17 @@ addons:
     - uuid-dev
 
 cache:
+  ccache
   directories:
-  - $HOME/.ccache
+    - $HOME/texlive
+    - $HOME/latexdiff
+    - $HOME/pdf2djvu
+    - $HOME/.ccache
 
 before_install:
-  - curl -L https://github.com/yihui/ubuntu-bin/releases/download/latest/texlive.tar.gz | tar zxC ~
-  - curl -L https://bitbucket.org/jwilk/pdf2djvu/downloads/pdf2djvu-0.9.4.tar.xz | tar xJC ~
-  - git clone --depth=1 https://github.com/ssaavedra/latexdiff.git ~/latexdiff
+  - [[ -d ~/texlive ]] || curl -L https://github.com/yihui/ubuntu-bin/releases/download/latest/texlive.tar.gz | tar zxC ~
+  - [[ -d ~/pdf2djvu ]] || curl -L https://bitbucket.org/jwilk/pdf2djvu/downloads/pdf2djvu-0.9.4.tar.xz | tar xJC ~
+  - [[ -d ~/latexdiff ]] || git clone --depth=1 https://github.com/ssaavedra/latexdiff.git ~/latexdiff
 install:
   - PATH=$HOME/texlive/bin/x86_64-linux:$PATH
   - PATH=$HOME/latexdiff:$PATH
@@ -46,8 +50,7 @@ install:
   - tlmgr install minitoc lettrine times rsfs cm-super
   - tlmgr install avantgar tex4ht
   - export PATH="/usr/lib/ccache:$PATH"
-  - mkdir ~/pdf2djvu
-  - (cd ~/pdf2djvu-0.9.4 && ./configure --prefix=$HOME/pdf2djvu && make && make install)
+  - [[ -d ~/pdf2djvu ]] || mkdir -p ~/pdf2djvu && (cd ~/pdf2djvu-0.9.4 && ./configure --prefix=$HOME/pdf2djvu && make && make install)
   - export PATH=$HOME/pdf2djvu/bin:$PATH
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 compiler: clang
 script:
   - make all
-  - pdf2djvu -o root.djvu root.pdf
+  - pdf2djvu --no-page-titles -j2 -o root.djvu root.pdf
 addons:
   apt:
     packages:
@@ -45,7 +45,9 @@ deploy:
   provider: releases
   api_key:
     secure: jBdUmKPvTnGVHhQ4TK6btEyyI1ozeSOceAQ4fuCRm267WuMd7VXlJ60/nV+ntDNUwyOt03kV+O3ZN8+XmdtWU/SOKa+Jm1Icj3hS7oxItENRrnld8oS4YVLYMyhXJxVccYCtvL/A57R23qro/t6xuJVdv5bna7JihOQPLFt8Q98wOVEwrHcbzzD4jHIH27OBfZp/i0iO6PjQywOalq1P5Vf8GXI9AtGW9i8n1jKOCf0bJSnwSAR+O4KjGll0GFf/1bbJ8ZaOpPpKVolHf3s6MsnlB0YELEjgeANkaovTT0N+ecKnzEgEs9AWKAL27oC7pREi7oiMfGNdiL7dJDKGT5EI+aLzqunXWBg1zpYKjMBg8I2FYI1Gjy+GZD3OxjC9d27OtE0B4vtaqbiEdJyoRGhespMrRuHUIBIWSEcX3OnMtQ+8/RiDQcFDPleFI9EwWAQJEsUI5Jse21z5uK93J5pnjO597Jvi+OkvdlnYQMteSSuQAnqhaSnwNuU6/31v1lfCT4Je7nk4Vq4dy11qhRAYO/HjiuP2ysHDxE9eKPiStL9dgOqVtYGMQEo4WYr8uLcbfWbvPVKPg0l5OdxIib5NhNI1E8QAhwL4kYj1xgh7VIWofEGeuB0KpagjLCc5J6uw36Z4duyrC9yHmLoW93Vu7DLG7oO/Xp08Ez/c1us=
-  file: root.pdf
+  file:
+    - root.pdf
+    - root.djvu
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: cpp
+compiler: clang
+script:
+  - make all
+  - pdf2djvu -o root.djvu root.pdf
+addons:
+  apt:
+    packages:
+    - autoconf
+    - automake
+    - djvulibre-bin
+    - fonts-linuxlibertine
+    - gettext
+    - libdjvulibre-dev
+    - libexiv2-dev
+    - libfontconfig1-dev
+    - libgraphicsmagick++1-dev
+    - libpoppler-cpp-dev
+    - libpoppler-dev
+    - libpoppler-glib-dev
+    - libxml2-utils
+    - pkg-config
+    - python-docutils
+    - python-imaging
+    - python-nose
+    - uuid-dev
+
+cache:
+  directories:
+  - $HOME/.ccache
+
+before_install:
+  - curl -L https://github.com/yihui/ubuntu-bin/releases/download/latest/texlive.tar.gz | tar zxC ~
+  - curl -L https://bitbucket.org/jwilk/pdf2djvu/downloads/pdf2djvu-0.9.4.tar.xz | tar xJC ~
+install:
+  - PATH=$HOME/texlive/bin/x86_64-linux:$PATH
+  - tlmgr install collection-langspanish
+  - tlmgr install minitoc
+  - tlmgr install lettrine
+  - export PATH="/usr/lib/ccache:$PATH"
+  - mkdir ~/pdf2djvu
+  - (cd ~/pdf2djvu-0.9.4 && ./configure --prefix=$HOME/pdf2djvu && make && make install)
+  - export PATH=$HOME/pdf2djvu/bin:$PATH
+deploy:
+  provider: releases
+  api_key:
+    secure: jBdUmKPvTnGVHhQ4TK6btEyyI1ozeSOceAQ4fuCRm267WuMd7VXlJ60/nV+ntDNUwyOt03kV+O3ZN8+XmdtWU/SOKa+Jm1Icj3hS7oxItENRrnld8oS4YVLYMyhXJxVccYCtvL/A57R23qro/t6xuJVdv5bna7JihOQPLFt8Q98wOVEwrHcbzzD4jHIH27OBfZp/i0iO6PjQywOalq1P5Vf8GXI9AtGW9i8n1jKOCf0bJSnwSAR+O4KjGll0GFf/1bbJ8ZaOpPpKVolHf3s6MsnlB0YELEjgeANkaovTT0N+ecKnzEgEs9AWKAL27oC7pREi7oiMfGNdiL7dJDKGT5EI+aLzqunXWBg1zpYKjMBg8I2FYI1Gjy+GZD3OxjC9d27OtE0B4vtaqbiEdJyoRGhespMrRuHUIBIWSEcX3OnMtQ+8/RiDQcFDPleFI9EwWAQJEsUI5Jse21z5uK93J5pnjO597Jvi+OkvdlnYQMteSSuQAnqhaSnwNuU6/31v1lfCT4Je7nk4Vq4dy11qhRAYO/HjiuP2ysHDxE9eKPiStL9dgOqVtYGMQEo4WYr8uLcbfWbvPVKPg0l5OdxIib5NhNI1E8QAhwL4kYj1xgh7VIWofEGeuB0KpagjLCc5J6uw36Z4duyrC9yHmLoW93Vu7DLG7oO/Xp08Ez/c1us=
+  file: root.pdf
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: cpp
 compiler: clang
 script:
+  - git remote add reviewer https://github.com/ssaavedra/pfc-vacmatch.git
+  - git fetch reviewer latest-review
+  - git branch -f latest-review reviewer/latest-review
   - make all
   - pdf2djvu --no-page-titles -j2 -o root.djvu root.pdf
+  - make root-diff.pdf || true
+  - pdf2djvu --no-page-titles -j2 -o root-diff.djvu root-diff.pdf
+  
 addons:
   apt:
     packages:
@@ -32,8 +38,10 @@ cache:
 before_install:
   - curl -L https://github.com/yihui/ubuntu-bin/releases/download/latest/texlive.tar.gz | tar zxC ~
   - curl -L https://bitbucket.org/jwilk/pdf2djvu/downloads/pdf2djvu-0.9.4.tar.xz | tar xJC ~
+  - git clone --depth=1 https://github.com/ssaavedra/latexdiff.git ~/latexdiff
 install:
   - PATH=$HOME/texlive/bin/x86_64-linux:$PATH
+  - PATH=$HOME/latexdiff:$PATH
   - tlmgr install collection-langspanish
   - tlmgr install minitoc lettrine times rsfs cm-super
   - tlmgr install avantgar tex4ht
@@ -48,6 +56,8 @@ deploy:
   file:
     - root.pdf
     - root.djvu
+    - root-diff.pdf
+    - root-diff.djvu
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ before_install:
 install:
   - PATH=$HOME/texlive/bin/x86_64-linux:$PATH
   - tlmgr install collection-langspanish
-  - tlmgr install minitoc
-  - tlmgr install lettrine
+  - tlmgr install minitoc lettrine times rsfs cm-super
+  - tlmgr install avantgar tex4ht
   - export PATH="/usr/lib/ccache:$PATH"
   - mkdir ~/pdf2djvu
   - (cd ~/pdf2djvu-0.9.4 && ./configure --prefix=$HOME/pdf2djvu && make && make install)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+INTERACTION ?= -interaction=nonstopmode
+
+.PHONY: all
+all: root.pdf
+
+root.pdf: root.tex
+	pdflatex $(INTERACTION) root.tex || true
+	pdflatex $(INTERACTION) root.tex
+#	biblatex bibliography
+#	pdflatex $(INTERACTION) root.tex
+#	pdflatex $(INTERACTION) root.tex
+
+clean:
+	rm -f *.aux *.lof *.log *.lot *.maf *.mtc* *.out *.toc

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ root-diff.pdf: root-diff.tex
 	pdflatex $(INTERACTION) root-diff.tex
 
 latexdiff:
-	rm -rf latexdiff
-	git clone "https://github.com/ssaavedra/latexdiff.git"
+	[ -d latexdiff ] || git clone "https://github.com/ssaavedra/latexdiff.git"
 
 clean:
 	rm -f *.aux *.lof *.log *.lot *.maf *.mtc* *.out *.toc *-diff*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
+REVIEW_BRANCH ?= latest-review
 INTERACTION ?= -interaction=nonstopmode
 
 .PHONY: all
@@ -11,5 +12,21 @@ root.pdf: root.tex
 #	pdflatex $(INTERACTION) root.tex
 #	pdflatex $(INTERACTION) root.tex
 
+root-diff.tex: latexdiff
+	PATH=$(PWD)/latexdiff:$(PATH) latexdiff-vc --git -r $(REVIEW_BRANCH) --flatten=1 --exclude-textcmd=chapter,section,subsection,subsubsection root.tex
+	mv root-diff$(REVIEW_BRANCH).tex root-diff.tex
+
+root-diff.pdf: root-diff.tex
+	pdflatex $(INTERACTION) root-diff.tex || true
+	pdflatex $(INTERACTION) root-diff.tex
+
+latexdiff:
+	rm -rf latexdiff
+	git clone "https://github.com/ssaavedra/latexdiff.git"
+
 clean:
-	rm -f *.aux *.lof *.log *.lot *.maf *.mtc* *.out *.toc
+	rm -f *.aux *.lof *.log *.lot *.maf *.mtc* *.out *.toc *-diff*
+
+dist-clean: clean
+	rm -rf latexdiff root.pdf
+

--- a/root.tex
+++ b/root.tex
@@ -36,7 +36,7 @@
  \dominitoc
 
 %%%% WARNING %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- \thispagestyle{empty} \todo[color=red,inline]{\mbox{}\vspace*{2cm}%
+ \thispagestyle{empty} \todo[color=red,inline,caption={}]{\mbox{}\vspace*{2cm}%
    \textbf{WARNING:}
 
    Fai merge cos meus cambios antes de editar o contido. Para empezar,


### PR DESCRIPTION
Agora constrúese o PDF automáticamente en Travis cada vez que se publique como release.

E tamén se constrúe un "diff" visual en PDF  cos cambios entre a última versión revisada e a última.

Para publicar unha nova versión (e sobreescribir a anterior latest) chega facer:

```
git tag --force latest && git push --tags --force
```

Ademais do PDF tamén se xenera un ficheiro DJVU (que é un formato con moita máis capacidade de compresión).

Tamén se xenera un ficheiro diff cos cambios dende a última vez que foi revisado (se queres cambiar esa parte para que xenere o diff que queiras, adiante; púxencho sobre todo de exemplo).
